### PR TITLE
Update raml title and baseUri

### DIFF
--- a/api_spec/main.raml
+++ b/api_spec/main.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: Metadata
+title: 0-Metadata
 version: 0.8.0
 baseUri: 'http://127.0.0.1:5000'
 mediaType: application/json

--- a/api_spec/main.raml
+++ b/api_spec/main.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: Metadata
 version: 0.8.0
-baseUri: 'http://127.0.0.1:5000/'
+baseUri: 'http://127.0.0.1:5000'
 mediaType: application/json
 protocols:
   - HTTPS

--- a/api_spec/main.raml
+++ b/api_spec/main.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: User/Group example api
+title: Metadata
 version: 0.8.0
 baseUri: 'http://127.0.0.1:5000/'
 mediaType: application/json

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -29,7 +29,7 @@ from .http_client import HTTPClient
 
 
 class Client:
-    def __init__(self, base_uri="http://127.0.0.1:5000/"):
+    def __init__(self, base_uri="http://127.0.0.1:5000"):
         http_client = HTTPClient(base_uri)
         self.acl = AclService(http_client)
         self.bdomain = BdomainService(http_client)


### PR DESCRIPTION
Update the title from `User/Group example api` to `Metadata`.

Remove trailing slash from .raml `baseUri`